### PR TITLE
[Feat] #1/달력 구현

### DIFF
--- a/src/components/Calendar/CalendarDays.tsx
+++ b/src/components/Calendar/CalendarDays.tsx
@@ -1,0 +1,137 @@
+import { RestDayProps } from '@hooks/useGetQueries';
+import { TaskProps, addTask } from '@features/taskSlice';
+import { memo, useContext } from 'react';
+import { ModalContext } from '@context/ModalContext';
+import { useAppDispatch, useAppSelector } from '@features/hooks';
+import styled from 'styled-components';
+import AddModal from '@components/common/Modal/AddModal';
+import PrevMonthDays from '@components/Calendar/PrevMonthDays';
+import CurrentMonthDays from '@components/Calendar/CurrentMonthDays';
+import NextMonthDays from '@components/Calendar/NextMonthDays';
+
+type CalendarDaysProps = {
+  today: string;
+  prevMonthDayList: string[];
+  currentMonthDayList: string[];
+  nextMonthDayList: string[];
+  restDays: RestDayProps[];
+};
+
+const CalendarDays = memo(
+  ({
+    today,
+    prevMonthDayList,
+    currentMonthDayList,
+    nextMonthDayList,
+    restDays,
+  }: CalendarDaysProps) => {
+    const { openModal } = useContext(ModalContext);
+    const dispatch = useAppDispatch();
+    const tasksByDate = useAppSelector((state) => state.task.tasks);
+
+    const handleAddTask = async (date: string) => {
+      const taskInfo = await openModal(<AddModal />).catch(() => false);
+      if (taskInfo) {
+        const newTask: TaskProps = {
+          taskName: taskInfo as string,
+          isHoliday: 'N',
+          locdate: date,
+          taskId: Date.now().toString(),
+        };
+        dispatch(addTask(newTask));
+      }
+    };
+
+    return (
+      <StyledDateGrid>
+        {prevMonthDayList.map((day) => (
+          <StyledPrevDates key={day} onClick={() => handleAddTask(day)}>
+            <PrevMonthDays
+              restDays={restDays}
+              day={day}
+              tasksByDate={tasksByDate}
+            />
+          </StyledPrevDates>
+        ))}
+
+        {currentMonthDayList.map((day) => (
+          <StyledCurDates key={day} onClick={() => handleAddTask(day)}>
+            <CurrentMonthDays
+              today={today}
+              restDays={restDays}
+              day={day}
+              tasksByDate={tasksByDate}
+            />
+          </StyledCurDates>
+        ))}
+
+        {nextMonthDayList.map((day) => (
+          <StyledNextDates key={day} onClick={() => handleAddTask(day)}>
+            <NextMonthDays
+              restDays={restDays}
+              day={day}
+              tasksByDate={tasksByDate}
+            />
+          </StyledNextDates>
+        ))}
+      </StyledDateGrid>
+    );
+  },
+);
+
+CalendarDays.displayName = 'CalendarDays';
+
+const StyledDateGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-template-rows: repeat(6, 1fr);
+  height: 100%;
+  font-size: 16px;
+  & > * {
+    display: flex;
+    flex-direction: column;
+    border-bottom: 1px solid var(--gray-6);
+    border-left: 1px solid var(--gray-6);
+    text-align: right;
+    &:nth-child(7n) {
+      border-right: 1px solid var(--gray-6);
+    }
+  }
+`;
+
+const StyledPrevDates = styled.div`
+  cursor: pointer;
+  padding: 4px;
+  height: 130px;
+  &:nth-child(7n + 1),
+  &:nth-child(7n) {
+    background-color: var(--gray-7);
+  }
+  color: var(--gray-5);
+`;
+
+const StyledCurDates = styled.div`
+  cursor: pointer;
+  padding: 4px;
+  height: 130px;
+  color: var(--gray-1);
+  &:nth-child(7n + 1),
+  &:nth-child(7n) {
+    background-color: var(--gray-7);
+    color: var(--gray-4);
+  }
+  overflow: hidden;
+`;
+
+const StyledNextDates = styled.div`
+  cursor: pointer;
+  padding: 4px;
+  height: 130px;
+  &:nth-child(7n + 1),
+  &:nth-child(7n) {
+    background-color: var(--gray-7);
+  }
+  color: var(--gray-5);
+`;
+
+export default CalendarDays;

--- a/src/components/Calendar/CalendarWeeks.tsx
+++ b/src/components/Calendar/CalendarWeeks.tsx
@@ -1,0 +1,39 @@
+import { memo } from 'react';
+import styled from 'styled-components';
+
+const week = ['일', '월', '화', '수', '목', '금', '토'];
+
+const CalendarWeeks = memo(() => {
+  return (
+    <StyledDayGrid>
+      {week.map((day, idx) => (
+        <StyledDayBox key={idx}>
+          <StyledDay $isWeekend={idx === 0 || idx === 6}>{day}</StyledDay>
+        </StyledDayBox>
+      ))}
+    </StyledDayGrid>
+  );
+});
+
+const StyledDayGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--gray-6);
+  text-align: right;
+`;
+
+const StyledDayBox = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: end;
+  height: 25px;
+  padding-right: 8px;
+`;
+
+const StyledDay = styled.div<{ $isWeekend: boolean }>`
+  color: ${({ $isWeekend }) =>
+    $isWeekend ? 'var(--gray-3)' : 'var(--gray-1)'};
+`;
+
+export default CalendarWeeks;

--- a/src/components/Calendar/CurrentMonthDays.tsx
+++ b/src/components/Calendar/CurrentMonthDays.tsx
@@ -1,0 +1,100 @@
+import { RestDayProps } from '@hooks/useGetQueries';
+import { extractDateInfo } from '@utils/extractFormat';
+import { memo } from 'react';
+import { TaskProps } from '@features/taskSlice';
+import styled from 'styled-components';
+import TaskList from '@components/Calendar/TaskList';
+
+type CurrentMonthDaysProps = {
+  today: string;
+  restDays: RestDayProps[];
+  day: string;
+  tasksByDate: TaskProps[];
+};
+
+const CurrentMonthDays = memo(
+  ({ today, restDays, day, tasksByDate }: CurrentMonthDaysProps) => {
+    return (
+      <>
+        <StyledContainer>
+          {extractDateInfo(day, 'day') === '1' && (
+            <StyledMonthContainer>
+              {extractDateInfo(day, 'month')}월
+            </StyledMonthContainer>
+          )}
+          <StyledTodayText $isToday={day === today}>
+            {extractDateInfo(day, 'day')}
+          </StyledTodayText>
+          <div>일</div>
+        </StyledContainer>
+        <StyledUl>
+          {restDays.map(
+            (restDay) =>
+              restDay.locdate === parseInt(day) && (
+                <TaskList
+                  key={restDay.seq}
+                  dateName={restDay.dateName}
+                  isHoliday={restDay.isHoliday}
+                />
+              ),
+          )}
+          {tasksByDate.map(
+            (task, idx) =>
+              task.locdate === day && (
+                <TaskList
+                  key={idx}
+                  dateName={task.taskName}
+                  isHoliday={task.isHoliday}
+                  taskId={task.taskId}
+                />
+              ),
+          )}
+        </StyledUl>
+      </>
+    );
+  },
+);
+
+CurrentMonthDays.displayName = 'CurrentMonthDays';
+
+const StyledContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  height: 38px;
+  min-height: 38px;
+  max-height: 38px;
+  padding-right: 8px;
+`;
+
+const StyledMonthContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  height: 40px;
+  padding-right: 4px;
+`;
+
+const StyledTodayText = styled.span<{ $isToday: boolean }>`
+  ${({ $isToday }) =>
+    $isToday &&
+    `
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 12px;
+    height: 12px;
+    padding: 14px;
+    border-radius: 50%;
+    background-color: red;
+    color: white;
+  `}
+`;
+
+const StyledUl = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+export default CurrentMonthDays;

--- a/src/components/Calendar/NextMonthDays.tsx
+++ b/src/components/Calendar/NextMonthDays.tsx
@@ -1,0 +1,67 @@
+import { RestDayProps } from '@hooks/useGetQueries';
+import { extractDateInfo } from '@utils/extractFormat';
+import { memo } from 'react';
+import { TaskProps } from '@features/taskSlice';
+import styled from 'styled-components';
+import TaskList from '@components/Calendar/TaskList';
+
+type NextMonthDaysProps = {
+  restDays: RestDayProps[];
+  day: string;
+  tasksByDate: TaskProps[];
+};
+
+const NextMonthDays = memo(
+  ({ restDays, day, tasksByDate }: NextMonthDaysProps) => {
+    return (
+      <>
+        <StyledContainer>
+          {extractDateInfo(day, 'day') === '1'
+            ? `${extractDateInfo(day, 'month')}월 1일`
+            : `${extractDateInfo(day, 'day')}일`}
+        </StyledContainer>
+        <StyledUl>
+          {restDays.map(
+            (restDay) =>
+              restDay.locdate === parseInt(day) && (
+                <TaskList
+                  key={restDay.seq}
+                  dateName={restDay.dateName}
+                  isHoliday={restDay.isHoliday}
+                />
+              ),
+          )}
+          {tasksByDate.map(
+            (task, idx) =>
+              task.locdate === day && (
+                <TaskList
+                  key={idx}
+                  dateName={task.taskName}
+                  isHoliday={task.isHoliday}
+                  taskId={task.taskId}
+                />
+              ),
+          )}
+        </StyledUl>
+      </>
+    );
+  },
+);
+
+NextMonthDays.displayName = 'NextMonthDays';
+
+const StyledContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  height: 40px;
+  padding-right: 8px;
+`;
+
+const StyledUl = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+export default NextMonthDays;

--- a/src/components/Calendar/PrevMonthDays.tsx
+++ b/src/components/Calendar/PrevMonthDays.tsx
@@ -1,0 +1,63 @@
+import { RestDayProps } from '@hooks/useGetQueries';
+import { extractDateInfo } from '@utils/extractFormat';
+import { memo } from 'react';
+import { TaskProps } from '@features/taskSlice';
+import styled from 'styled-components';
+import TaskList from '@components/Calendar/TaskList';
+
+type PrevMonthDaysProps = {
+  restDays: RestDayProps[];
+  day: string;
+  tasksByDate: TaskProps[];
+};
+
+const PrevMonthDays = memo(
+  ({ restDays, day, tasksByDate }: PrevMonthDaysProps) => {
+    return (
+      <>
+        <StyledContainer>{`${extractDateInfo(day, 'day')}일`}</StyledContainer>
+        <StyledUl>
+          {restDays.map(
+            (restDay) =>
+              restDay.locdate === parseInt(day) && (
+                <TaskList
+                  key={restDay.seq}
+                  dateName={restDay.dateName}
+                  isHoliday={restDay.isHoliday}
+                />
+              ),
+          )}
+          {tasksByDate.map(
+            (task, idx) =>
+              task.locdate === day && (
+                <TaskList
+                  key={idx}
+                  dateName={task.taskName}
+                  isHoliday={task.isHoliday}
+                  taskId={task.taskId}
+                />
+              ),
+          )}
+        </StyledUl>
+      </>
+    );
+  },
+);
+
+PrevMonthDays.displayName = 'PrevMonthDays';
+
+const StyledContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  height: 40px;
+  padding-right: 8px;
+`;
+
+const StyledUl = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+export default PrevMonthDays;

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -1,0 +1,51 @@
+import { memo } from 'react';
+import { useRestDayInfo } from '@hooks/useGetQueries';
+import styled from 'styled-components';
+import useCalendar from '@hooks/useCalendar';
+import Header from '@components/common/Header';
+import CalendarDays from '@components/Calendar/CalendarDays';
+import CalendarWeeks from '@components/Calendar/CalendarWeeks';
+
+const Calendar = memo(() => {
+  const {
+    today,
+    curCalendar,
+    currentYear,
+    handlePreviousMonth,
+    handleNextMonth,
+    handleToday,
+    prevMonthDayList,
+    currentMonthDayList,
+    nextMonthDayList,
+  } = useCalendar();
+  const { data: restDays } = useRestDayInfo(currentYear);
+  return (
+    <>
+      <Header
+        curCalendar={curCalendar}
+        handlePreviousMonth={handlePreviousMonth}
+        handleNextMonth={handleNextMonth}
+        handleToday={handleToday}
+      />
+      <StyledContainer>
+        <CalendarWeeks />
+        <CalendarDays
+          today={today}
+          prevMonthDayList={prevMonthDayList}
+          currentMonthDayList={currentMonthDayList}
+          nextMonthDayList={nextMonthDayList}
+          restDays={restDays}
+        />
+      </StyledContainer>
+    </>
+  );
+});
+
+Calendar.displayName = 'Calendar';
+
+const StyledContainer = styled.div`
+  height: 100%;
+  border-collapse: collapse;
+`;
+
+export default Calendar;

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+import ArrowRight from '@assets/arrow_right.svg';
+import ArrowLeft from '@assets/arrow_left.svg';
+import { memo } from 'react';
+
+type HeaderProps = {
+  curCalendar: Date;
+  handlePreviousMonth: () => void;
+  handleNextMonth: () => void;
+  handleToday: () => void;
+};
+
+const Header = memo(
+  ({
+    curCalendar,
+    handlePreviousMonth,
+    handleNextMonth,
+    handleToday,
+  }: HeaderProps) => {
+    return (
+      <StyledContainer>
+        <StyledYear>
+          {curCalendar.getFullYear()}년 {curCalendar.getMonth() + 1}월
+        </StyledYear>
+        <StyledBtnContainer>
+          <StyledBtn onClick={handlePreviousMonth}>
+            <StyledIcon src={ArrowLeft} />
+          </StyledBtn>
+          <StyledTodayBtn onClick={handleToday}>오늘</StyledTodayBtn>
+          <StyledBtn onClick={handleNextMonth}>
+            <StyledIcon src={ArrowRight} />
+          </StyledBtn>
+        </StyledBtnContainer>
+      </StyledContainer>
+    );
+  },
+);
+
+Header.displayName = 'Header';
+
+const StyledContainer = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+`;
+
+const StyledYear = styled.h1`
+  font-size: 34px;
+  font-weight: 700;
+`;
+
+const StyledBtnContainer = styled.div`
+  display: flex;
+  align-items: center;
+  height: 25px;
+`;
+
+const StyledBtn = styled.button`
+  border: 1px solid var(--gray-5);
+  border-radius: 8px;
+  padding: 2px 4px;
+  height: 100%;
+`;
+
+const StyledTodayBtn = styled.button`
+  border: 1px solid var(--gray-5);
+  border-radius: 8px;
+  padding: 2px 12px;
+  height: 100%;
+`;
+
+const StyledIcon = styled.img`
+  width: 14px;
+  height: 14px;
+`;
+
+export default Header;

--- a/src/components/common/Layout/index.tsx
+++ b/src/components/common/Layout/index.tsx
@@ -1,0 +1,24 @@
+import useInnerHeight from '@hooks/useInnerHeight';
+import { memo } from 'react';
+import styled from 'styled-components';
+
+type LayoutProps = {
+  children: React.ReactNode;
+};
+
+const Layout = memo(({ children }: LayoutProps) => {
+  const { height } = useInnerHeight();
+  return <StyledLayout $height={height}>{children}</StyledLayout>;
+});
+
+Layout.displayName = 'Layout';
+
+const StyledLayout = styled.main<{ $height: number }>`
+  display: flex;
+  flex-direction: column;
+  max-width: 1240px;
+  margin: 0 auto;
+  min-height: ${({ $height }) => `${$height}vh`};
+`;
+
+export default Layout;

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -1,0 +1,81 @@
+import { getCurMonthFirstDay } from '@utils/getCurMonthFirstDay';
+import { getDaysInMonth } from '@utils/getDaysInMonth';
+import { getFormatDate } from '@utils/getFormatDate';
+import { useState } from 'react';
+
+const CALENDAR_LENGTH = 42;
+
+const useCalendar = () => {
+  const [curCalendar, setCurCalendar] = useState<Date>(() =>
+    getCurMonthFirstDay(new Date()),
+  );
+  const totalMonthDays = getDaysInMonth(curCalendar);
+  const currentYear = curCalendar.getFullYear().toString();
+  const today = getFormatDate(new Date());
+
+  const handleToday = () => {
+    setCurCalendar(getCurMonthFirstDay(new Date()));
+  };
+
+  const handlePreviousMonth = () => {
+    setCurCalendar(
+      new Date(curCalendar.getFullYear(), curCalendar.getMonth() - 1, 1),
+    );
+  };
+
+  const handleNextMonth = () => {
+    setCurCalendar(
+      new Date(curCalendar.getFullYear(), curCalendar.getMonth() + 1, 1),
+    );
+  };
+
+  const prevLastDay = new Date(
+    curCalendar.getFullYear(),
+    curCalendar.getMonth(),
+    0,
+  );
+  const prevMonthLastDate = prevLastDay.getDate();
+
+  const prevMonthDayList = Array.from({
+    length: curCalendar.getDay(),
+  })
+    .map((_, idx) =>
+      getFormatDate(
+        new Date(
+          curCalendar.getFullYear(),
+          curCalendar.getMonth() - 1,
+          prevMonthLastDate - idx,
+        ),
+      ),
+    )
+    .reverse();
+
+  const currentMonthDayList = Array.from({ length: totalMonthDays }).map(
+    (_, i) =>
+      getFormatDate(
+        new Date(curCalendar.getFullYear(), curCalendar.getMonth(), i + 1),
+      ),
+  );
+
+  const nextMonthDayList = Array.from({
+    length:
+      CALENDAR_LENGTH - currentMonthDayList.length - prevMonthDayList.length,
+  }).map((_, idx) =>
+    getFormatDate(
+      new Date(curCalendar.getFullYear(), curCalendar.getMonth() + 1, idx + 1),
+    ),
+  );
+
+  return {
+    today,
+    curCalendar,
+    currentYear,
+    handlePreviousMonth,
+    handleNextMonth,
+    handleToday,
+    prevMonthDayList,
+    currentMonthDayList,
+    nextMonthDayList,
+  };
+};
+export default useCalendar;

--- a/src/hooks/useGetQueries.ts
+++ b/src/hooks/useGetQueries.ts
@@ -1,0 +1,28 @@
+import instance from '@apis/instance';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export type RestDayProps = {
+  dateKind: string;
+  dateName: string;
+  isHoliday: 'Y' | 'N';
+  locdate: number;
+  seq: number;
+};
+
+export const useRestDayInfo = (year: string) => {
+  return useSuspenseQuery({
+    queryKey: ['restDay', year],
+    queryFn: async (): Promise<RestDayProps[]> => {
+      const { data } = await instance.get('getRestDeInfo', {
+        params: {
+          solYear: year,
+          ServiceKey:
+            'vbdVUJI1hwCp2h0xCS8e1SJawvT7jGJKNMeUtDvBTGEWXgkZAEKFyd77HpGRX2Op4QaCn48JKs9O1DXES4NYKA==',
+          _type: 'json',
+          numOfRows: 20,
+        },
+      });
+      return data.response.body.items.item;
+    },
+  });
+};

--- a/src/hooks/useInnerHeight.ts
+++ b/src/hooks/useInnerHeight.ts
@@ -1,0 +1,20 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const useInnerHeight = (): { height: number } => {
+  const [height, setHeight] = useState<number>(window.innerHeight);
+
+  const setScreenHeight = useCallback(() => {
+    const vh = window.innerHeight * 0.1;
+    setHeight(vh);
+  }, []);
+
+  useEffect(() => {
+    setScreenHeight();
+    window.addEventListener('resize', setScreenHeight);
+    return () => window.removeEventListener('resize', setScreenHeight);
+  }, [setScreenHeight]);
+
+  return { height };
+};
+
+export default useInnerHeight;

--- a/src/utils/extractFormat.ts
+++ b/src/utils/extractFormat.ts
@@ -1,0 +1,21 @@
+export const extractDateInfo = (
+  date: string,
+  type: 'year' | 'month' | 'day',
+) => {
+  const [year, month, day] = [
+    date.substring(0, 4),
+    parseInt(date.substring(4, 6), 10).toString(),
+    parseInt(date.substring(6, 8), 10).toString(),
+  ];
+
+  switch (type) {
+    case 'year':
+      return year;
+    case 'month':
+      return month;
+    case 'day':
+      return day;
+    default:
+      throw new Error('Invalid type');
+  }
+};

--- a/src/utils/getCurMonthFirstDay.ts
+++ b/src/utils/getCurMonthFirstDay.ts
@@ -1,0 +1,5 @@
+export const getCurMonthFirstDay = (date: Date): Date => {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  return new Date(year, month, 1);
+};

--- a/src/utils/getDaysInMonth.ts
+++ b/src/utils/getDaysInMonth.ts
@@ -1,0 +1,5 @@
+export const getDaysInMonth = (date: Date): number => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1; // 월은 0부터 시작하므로 1을 더합니다.
+  return new Date(year, month, 0).getDate();
+};

--- a/src/utils/getFormatDate.ts
+++ b/src/utils/getFormatDate.ts
@@ -1,0 +1,6 @@
+export const getFormatDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}${month}${day}`;
+};


### PR DESCRIPTION
- 달력을 사용하는 데 필요한 기능들을 담은 `useCalendar` 훅을 작성했습니다.
- `useCalendar` 훅 내부에서 사용하는 `날짜 정보 추출`, `날짜 포맷팅`, `날짜 수 추출`, `Date 반환`의 유틸함수를 작성했습니다.
- 달력을 구성하는 데 필요한 요일, 날짜 부분을 컴포넌트로 분리하여 구현했습니다.
- 현재 년도와 월을 보여주고, 달을 이동할 수 있는 버튼으로 구성된 헤더 컴포넌트를 작성했습니다.
- 현재 달 1일 기준의 요일을 통해 렌더링 해야할 이전 달의 개수를 파악하고, 현재 달의 모든 날짜, 6주로 구성된 42개의 날짜 - (이전 달의 개수 + 현재 달의 모든 날짜)로 구성하여 달력 렌더링을 진행했습니다.

close #1 

