### PR TITLE
[Feat] /#3/task

### DIFF
--- a/src/@types/modal.ts
+++ b/src/@types/modal.ts
@@ -1,0 +1,4 @@
+export type ModalProps = {
+  onSubmit?: <T>(type: T) => void;
+  onAbort?: (type: Error) => void;
+};

--- a/src/components/Calendar/TaskList.tsx
+++ b/src/components/Calendar/TaskList.tsx
@@ -1,0 +1,64 @@
+import { ModalContext } from '@context/ModalContext';
+import { removeTask } from '@features/taskSlice';
+import { memo, useContext } from 'react';
+import { useAppDispatch } from '@features/hooks';
+import styled from 'styled-components';
+import DeleteModal from '@components/common/Modal/DeleteModal';
+
+type TaskListProps = {
+  taskId?: string;
+  dateName: string;
+  isHoliday: 'Y' | 'N';
+  locdate?: string;
+};
+
+const TaskList = memo(({ dateName, isHoliday, taskId }: TaskListProps) => {
+  const dispatch = useAppDispatch();
+  const { openModal } = useContext(ModalContext);
+
+  const handleRemoveTask = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (taskId) {
+      const isDelete = await openModal(<DeleteModal />).catch(() => false);
+      if (isDelete) {
+        dispatch(removeTask({ taskId }));
+      }
+    }
+  };
+
+  return (
+    <ListItem $isHoliday={isHoliday} onClick={handleRemoveTask}>
+      {isHoliday === 'N' && <StyledSpan />}
+      {dateName}
+    </ListItem>
+  );
+});
+
+TaskList.displayName = 'TaskList';
+
+const ListItem = styled.li<{ $isHoliday: 'Y' | 'N' }>`
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding: 4px;
+  font-size: 12px;
+  color: ${({ $isHoliday }) =>
+    $isHoliday === 'N' ? 'white' : 'var(--gray-1)'};
+  border-radius: 4px;
+  background-color: ${({ $isHoliday }) =>
+    $isHoliday === 'Y' ? 'var(--holiday)' : 'var(--task)'};
+`;
+
+const StyledSpan = styled.span`
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: white;
+  margin-right: 2px;
+`;
+
+export default TaskList;

--- a/src/components/common/Loader/index.tsx
+++ b/src/components/common/Loader/index.tsx
@@ -1,0 +1,34 @@
+import { memo } from 'react';
+import styled, { keyframes } from 'styled-components';
+
+const Loader = memo(() => {
+  return (
+    <StyledLoader>
+      <Spinner />
+    </StyledLoader>
+  );
+});
+
+const StyledLoader = styled.div`
+  width: 100%;
+  height: 80vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const spinAnimation = keyframes`
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+`;
+
+const Spinner = styled.div`
+  border: 5px solid rgba(0, 0, 0, 0.1);
+  border-top: 5px solid var(--task);
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  animation: ${spinAnimation} 1s linear infinite;
+`;
+
+export default Loader;

--- a/src/components/common/Modal/AddModal.tsx
+++ b/src/components/common/Modal/AddModal.tsx
@@ -1,0 +1,101 @@
+import { memo, useState } from 'react';
+import { ModalProps } from 'src/@types/modal';
+import styled from 'styled-components';
+
+const AddModal = memo(({ onSubmit, onAbort }: ModalProps) => {
+  const [taskInfo, setTaskInfo] = useState<string>('');
+  const handleOutside = (e: React.MouseEvent) => {
+    if (e.target !== e.currentTarget) return;
+    e.stopPropagation();
+    onAbort?.(new Error());
+  };
+  return (
+    <StyledWrapper onClick={handleOutside}>
+      <StyledContainer>
+        <StyledFlexContainer>
+          <StyledSpan>추가할 할일을 입력해주세요.</StyledSpan>
+          <StyledInput onChange={(e) => setTaskInfo(e.target.value)} />
+          <StyledButtonContainer>
+            <StyledButton
+              onClick={() => {
+                onAbort?.(new Error());
+              }}
+              $colorType="disabled"
+            >
+              취소
+            </StyledButton>
+            <StyledButton
+              onClick={() => {
+                onSubmit?.(taskInfo);
+              }}
+              $colorType="active"
+            >
+              추가하기
+            </StyledButton>
+          </StyledButtonContainer>
+        </StyledFlexContainer>
+      </StyledContainer>
+    </StyledWrapper>
+  );
+});
+
+AddModal.displayName = 'AddModal';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(11, 19, 30, 0.37);
+  backdrop-filter: blur(5px);
+  top: 0;
+  left: 0;
+  z-index: 99;
+`;
+
+const StyledContainer = styled.article`
+  width: 360px;
+  height: 273px;
+  margin: auto;
+  padding: 24px;
+  background-color: var(--white);
+  border-radius: 8px;
+  text-align: center;
+`;
+
+const StyledFlexContainer = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+`;
+
+const StyledSpan = styled.span`
+  font-size: 16px;
+  font-weight: 400;
+  white-space: pre-wrap;
+`;
+
+const StyledButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+`;
+
+const StyledInput = styled.input`
+  border: 1px solid var(--gray-4);
+  border-radius: 8px;
+  padding: 12px;
+`;
+
+const StyledButton = styled.button<{ $colorType: 'disabled' | 'active' }>`
+  width: 100%;
+  padding: 12px;
+  background-color: ${({ $colorType }) =>
+    $colorType === 'active' ? 'var(--task)' : 'var(--gray-4)'};
+  color: var(--white);
+  border-radius: 8px;
+`;
+
+export default AddModal;

--- a/src/components/common/Modal/DeleteModal.tsx
+++ b/src/components/common/Modal/DeleteModal.tsx
@@ -1,0 +1,93 @@
+import { memo } from 'react';
+import { ModalProps } from 'src/@types/modal';
+import styled from 'styled-components';
+
+const DeleteModal = memo(({ onSubmit, onAbort }: ModalProps) => {
+  const handleOutside = (e: React.MouseEvent) => {
+    if (e.target !== e.currentTarget) return;
+    e.stopPropagation();
+    onAbort?.(new Error());
+  };
+  return (
+    <StyledWrapper onClick={handleOutside}>
+      <StyledContainer>
+        <StyledFlexContainer>
+          <StyledSpan>정말 할일을 삭제하시겠습니까?</StyledSpan>
+          <StyledButtonContainer>
+            <StyledButton
+              onClick={() => {
+                onAbort?.(new Error());
+              }}
+              $colorType="disabled"
+            >
+              취소
+            </StyledButton>
+            <StyledButton
+              onClick={() => {
+                onSubmit?.(true);
+              }}
+              $colorType="active"
+            >
+              삭제하기
+            </StyledButton>
+          </StyledButtonContainer>
+        </StyledFlexContainer>
+      </StyledContainer>
+    </StyledWrapper>
+  );
+});
+
+DeleteModal.displayName = 'DeleteModal';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(11, 19, 30, 0.37);
+  backdrop-filter: blur(5px);
+  top: 0;
+  left: 0;
+  z-index: 99;
+`;
+
+const StyledContainer = styled.article`
+  width: 360px;
+  height: 273px;
+  margin: auto;
+  padding: 24px;
+  background-color: var(--white);
+  border-radius: 8px;
+  text-align: center;
+`;
+
+const StyledFlexContainer = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+`;
+
+const StyledSpan = styled.span`
+  font-size: 16px;
+  font-weight: 400;
+  white-space: pre-wrap;
+`;
+
+const StyledButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+`;
+
+const StyledButton = styled.button<{ $colorType: 'disabled' | 'active' }>`
+  width: 100%;
+  padding: 12px;
+  background-color: ${({ $colorType }) =>
+    $colorType === 'active' ? 'var(--task)' : 'var(--gray-4)'};
+  color: var(--white);
+  border-radius: 8px;
+`;
+
+export default DeleteModal;

--- a/src/context/ModalContext.tsx
+++ b/src/context/ModalContext.tsx
@@ -1,0 +1,75 @@
+import {
+  createContext,
+  useState,
+  useEffect,
+  cloneElement,
+  Fragment,
+} from 'react';
+import { useLocation } from 'react-router-dom';
+
+type ModalProps = {
+  openModal: <T extends {}>(element: React.ReactElement) => Promise<T>;
+  hideModal: () => void;
+  modals: React.ReactElement[];
+};
+
+interface Props {
+  children: JSX.Element | JSX.Element[];
+}
+
+const ModalContext = createContext<ModalProps>({
+  openModal: async () => Promise.resolve({} as any),
+  hideModal: () => {},
+  modals: [],
+});
+
+const ModalProvider = ({ children }: Props): JSX.Element => {
+  const [modals, setModals] = useState<React.ReactElement[]>([]);
+  const location = useLocation();
+
+  useEffect(() => {
+    setModals([]);
+  }, [location]);
+
+  const openModal = <T extends {}>(element: React.ReactElement): Promise<T> => {
+    const promiseResolver = () => {
+      let resolveFn: (value: T) => void = () => {};
+      let rejectFn: (ex: Error) => void = () => {};
+      const promise: Promise<T> = new Promise((resolve, reject) => {
+        resolveFn = resolve;
+        rejectFn = reject;
+      });
+      return { promise, resolveFn, rejectFn };
+    };
+    const { promise, resolveFn, rejectFn } = promiseResolver();
+
+    const modal: React.ReactElement = cloneElement(element, {
+      onSubmit: (value: T) => {
+        resolveFn(value);
+        setModals((prev) => prev.slice(0, -1));
+      },
+      onAbort: (ex: Error) => {
+        rejectFn(ex);
+        setModals((prev) => prev.slice(0, -1));
+      },
+    });
+    setModals((prev) => [...prev, modal]);
+    return promise;
+  };
+
+  const hideModal = () => {
+    modals.at(-1)?.props.onSubmit(false);
+    setModals((prev) => prev.slice(0, -1));
+  };
+
+  return (
+    <ModalContext.Provider value={{ openModal, hideModal, modals }}>
+      {children}
+      {modals.map((modal, idx) => (
+        <Fragment key={idx}>{modal}</Fragment>
+      ))}
+    </ModalContext.Provider>
+  );
+};
+
+export { ModalContext, ModalProvider };

--- a/src/features/hooks.ts
+++ b/src/features/hooks.ts
@@ -1,0 +1,7 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import type { TypedUseSelectorHook } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import taskReducer from '@features/taskSlice';
+
+const store = configureStore({
+  reducer: {
+    task: taskReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+
+export default store;

--- a/src/features/taskSlice.ts
+++ b/src/features/taskSlice.ts
@@ -1,0 +1,30 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export type TaskProps = {
+  taskId: string;
+  taskName: string;
+  isHoliday: 'Y' | 'N';
+  locdate: string;
+};
+
+const initialState: { tasks: TaskProps[] } = {
+  tasks: [],
+};
+
+const taskSlice = createSlice({
+  name: 'task',
+  initialState,
+  reducers: {
+    addTask: (state, action: PayloadAction<TaskProps>) => {
+      state.tasks = [...state.tasks, action.payload];
+    },
+    removeTask: (state, action: PayloadAction<{ taskId: string }>) => {
+      const { taskId } = action.payload;
+      state.tasks = state.tasks.filter((task) => task.taskId !== taskId);
+    },
+  },
+});
+
+export const { addTask, removeTask } = taskSlice.actions;
+
+export default taskSlice.reducer;


### PR DESCRIPTION
- `task`를 전역으로 관리하기 위한 전역 상태 관리 라이브러리 `redux` & `toolkit`을 도입하여 `store` 및 `slice`를 작성했습니다.
- `task`를 추가할 때 입력값을 받기 위해서 모달을 구현하고 `context`를 통해 관리하도록 구현했습니다.
- `taskList` 컴포넌트를 생성했습니다.

![preview-test](https://github.com/GeonwooShin/preview-test/assets/79186378/dd85552d-f0bd-4cce-9d3c-017040fc231b)


- 위와 같이 해당 일자를 클릭하여 입력 값을 넣고 task를 추가합니다.
- task를 삭제할 때는 해당 task를 클릭하고 모달의 삭제 버튼을 누릅니다.

close #3 